### PR TITLE
[Bugfix] fixed initAttempt initialisation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "stats",
     "embedded metric format"
   ],
+  "files": ["dist"],
   "author": {
     "name": "Simone Spaccarotella",
     "email": "simone.spaccarotella@bbc.co.uk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bbc/http-transport-emf-stats",
-  "version": "0.1.0-beta",
+  "version": "0.1.1-beta",
   "description": "An EMF stats adapter for HTTP transport",
   "main": "dist/http-transport-emf-stats.cjs.js",
   "module": "dist/http-transport-emf-stats.es.js",

--- a/src/stats.js
+++ b/src/stats.js
@@ -6,7 +6,7 @@ export default async function stats(emitter, upstreamName, context, next) {
   // flags the presence of an upstream response
   let withResponse = true;
   // init the current attempt
-  const attempt = init.initAttempt();
+  const attempt = init.initAttempt(emitter);
   // init the cache audit array
   const cacheAudit = [];
 

--- a/test/stats.test.js
+++ b/test/stats.test.js
@@ -22,12 +22,23 @@ describe('[src/stats.js]', () => {
 
   afterEach(() => sinon.restore());
 
-  it('should init the attempt object', async () => {
-    sinon.stub(init, 'initAttempt').returns({});
+  describe('attempt object initialisation', () => {
+    it('should call "initAttempt" with undefined if the emitter is not defined', async () => {
+      sinon.stub(init, 'initAttempt').returns({});
+      emitter = undefined;
 
-    await stats(emitter, clientName, context, next);
+      await stats(emitter, clientName, context, next);
 
-    sinon.assert.calledOnce(init.initAttempt);
+      sinon.assert.calledOnceWithExactly(init.initAttempt, undefined);
+    });
+
+    it('should call "initAttempt" with the emitter if set', async () => {
+      sinon.stub(init, 'initAttempt').returns({});
+
+      await stats(emitter, clientName, context, next);
+
+      sinon.assert.calledOnceWithExactly(init.initAttempt, emitter);
+    });
   });
 
   it('should attach the cache event listeners', async () => {


### PR DESCRIPTION
## Summary
The stats plugin was calling the "initAttempt" utility function without passing the emitter. This was causing the plugin to always initialise the cache object to null, leading to `TypeError` due to a property being set to the null pointer.

## Changelog
* Passed the `emitter` object to the `initAttempt` function
* Updated unit test